### PR TITLE
fix farming mod detection

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -560,7 +560,7 @@ local a = {
    },
 }
 
-if farming then
+if minetest.get_modpath("farming") then
    table.insert(a,
 		{ name = 'agro_begins',
 		  title = "Découverte de l'agriculture",


### PR DESCRIPTION
Before it didn't trigger this action and gave a warning about
`"Undeclared global variable "farming" accessed at
....\sys4_achievements\init.lua:563"`
